### PR TITLE
Fix app hang on startup/shutdown with no internet connection

### DIFF
--- a/TimeTrackerSOAP_Server.py
+++ b/TimeTrackerSOAP_Server.py
@@ -2,8 +2,86 @@ import json
 import os
 import sys
 import logging
+import types
+import importlib.util
 from wsgiref.simple_server import make_server
 from datetime import datetime
+
+
+def _patch_spyne_vendored_six():
+    """
+    spyne 2.14.0 (the only release on PyPI) vendors an old copy of `six`
+    (spyne/util/six.py) whose meta path importer only implements the legacy
+    PEP 302 find_module()/load_module() protocol. Python 3.12 dropped the
+    compatibility shim that let the import system fall back to find_module()
+    when find_spec() (PEP 451) is missing, so every `spyne.util.six.moves.*`
+    import - including one hit while `spyne/__init__.py` itself is still
+    running - fails with "ModuleNotFoundError: No module named
+    'spyne.util.six.moves'". Upstream issue (open, unreleased as of
+    2026-08): https://github.com/arskom/spyne/issues/711
+
+    Fix: load spyne's vendored six.py directly under its real module name
+    (without triggering the still-broken `import spyne`) and add a
+    find_spec() to its meta path importer, mirroring the fix already present
+    in the real `six` package (>=1.15). The importer instance stays
+    registered in sys.meta_path for the rest of the process, so the normal
+    `import spyne` below - and every later `spyne.util.six.moves` import
+    inside spyne - resolves correctly.
+    """
+    if 'spyne.util.six' in sys.modules:
+        return
+
+    spyne_spec = importlib.util.find_spec('spyne')
+    if spyne_spec is None or not spyne_spec.submodule_search_locations:
+        return
+
+    six_path = os.path.join(spyne_spec.submodule_search_locations[0], 'util', 'six.py')
+    if not os.path.isfile(six_path):
+        return
+
+    six_spec = importlib.util.spec_from_file_location('spyne.util.six', six_path)
+    six_module = importlib.util.module_from_spec(six_spec)
+    sys.modules['spyne.util.six'] = six_module
+    six_spec.loader.exec_module(six_module)
+
+    importer = getattr(six_module, '_importer', None)
+    if importer is not None and not hasattr(importer, 'find_spec'):
+        def find_spec(self, fullname, path=None, target=None):
+            if fullname in self.known_modules:
+                return importlib.util.spec_from_loader(fullname, self)
+            return None
+        importer.find_spec = find_spec.__get__(importer)
+
+
+def _patch_missing_cgi_module():
+    """
+    spyne 2.14.0's SOAP11 protocol and WSGI transport (both used by this
+    server) still do `import cgi` to parse the Content-Type header. Python
+    3.13 removed the `cgi` module from the standard library (PEP 594), so on
+    3.13+ this raises "ModuleNotFoundError: No module named 'cgi'" - a
+    second, independent break from the six.moves issue above. Spyne's master
+    branch fixes this (unreleased) by parsing Content-Type via
+    email.message.EmailMessage instead; provide a minimal `cgi` stand-in
+    with the same fix so `import cgi` keeps working until spyne cuts a new
+    release.
+    """
+    if 'cgi' in sys.modules or importlib.util.find_spec('cgi') is not None:
+        return
+
+    from email.message import EmailMessage
+
+    def parse_header(line):
+        msg = EmailMessage()
+        msg['content-type'] = line
+        return msg.get_content_type(), dict(msg['content-type'].params)
+
+    cgi_stub = types.ModuleType('cgi')
+    cgi_stub.parse_header = parse_header
+    sys.modules['cgi'] = cgi_stub
+
+
+_patch_spyne_vendored_six()
+_patch_missing_cgi_module()
 
 # Attempt to import Spyne. This is the standard library for SOAP in Python.
 try:

--- a/install.py
+++ b/install.py
@@ -58,10 +58,17 @@ def check_and_install_requirements():
     if requirements_to_install:
         print(f"Fehlende Pakete werden installiert: {', '.join(requirements_to_install)}")
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install"] + requirements_to_install)
+            # See tt/TimeTracker.py's PIP_INSTALL_TIMEOUT for why this needs an
+            # explicit timeout: with no internet connection, DNS resolution can
+            # hang far longer than pip's own request timeouts, and
+            # subprocess.check_call() has no bound of its own unless given one.
+            subprocess.check_call([sys.executable, "-m", "pip", "install"] + requirements_to_install, timeout=120)
             print("\nAlle Abhängigkeiten wurden erfolgreich installiert.")
         except subprocess.CalledProcessError:
             print("\nFehler bei der Installation der Abhängigkeiten.")
+            sys.exit(1)
+        except subprocess.TimeoutExpired:
+            print("\nZeitüberschreitung bei der Installation der Abhängigkeiten (keine Internetverbindung?).")
             sys.exit(1)
     else:
         print("Alle Abhängigkeiten sind bereits erfüllt.")

--- a/sl/SL_Menu.py
+++ b/sl/SL_Menu.py
@@ -15,7 +15,7 @@ from tt.TimeTracker import TimeTracker
 from i18n import _
 
 try:
-    from update import restore_previous_version, check_for_updates, apply_update
+    from update import restore_previous_version, check_for_updates, apply_update, should_check_for_updates
     UPDATE_MODULE_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
     UPDATE_MODULE_AVAILABLE = False
@@ -315,16 +315,7 @@ if 'tracker' not in st.session_state:
     st.session_state.tracker = TimeTracker()
     st.session_state.tracker.initialize_dependencies()
     st.session_state.tracker.set_today_flag_for_due_tasks() # Set 'today' flag for tasks due today
-
-    # One check per session, not per rerun (Streamlit reruns this whole
-    # script on every click) - a frozen build has no loose source files for
-    # the update mechanism to overwrite (see update.py/TimeTrackerSL_GUI.py),
-    # so there's nothing to offer there.
     st.session_state.update_check = {'available': False}
-    if UPDATE_MODULE_AVAILABLE and not getattr(sys, 'frozen', False):
-        is_available, new_version, url = check_for_updates(st.session_state.tracker.get_version())
-        if is_available:
-            st.session_state.update_check = {'available': True, 'version': new_version, 'url': url}
 else:
     # Reload from disk on every rerun (i.e. on every click/navigation), so
     # changes made by another process sharing the same data file - the SOAP
@@ -343,6 +334,25 @@ else:
 
 if 'menu' not in st.session_state:
     st.session_state.menu = 'today_view'
+
+# Re-check for a new release whenever the view changes (navigating to a
+# different menu than the one this ran for last time) - not on every rerun
+# of the *same* view, e.g. not on every keystroke or the 5s auto-refresh
+# tick, which would hit GitHub far more often than the view itself changes.
+# A frozen build has no loose source files for the update mechanism to
+# overwrite (see update.py/TimeTrackerSL_GUI.py), so there's nothing to
+# offer there. check_for_updates() is itself immune to a dead network - it
+# runs under a hard deadline and never raises (see update.py) - so a flaky
+# connection just means this silently stays skipped instead of hanging the
+# view change or crashing.
+if (UPDATE_MODULE_AVAILABLE and not getattr(sys, 'frozen', False)
+        and should_check_for_updates(st.session_state, st.session_state.menu)):
+    st.session_state._update_checked_for_menu = st.session_state.menu
+    is_available, new_version, url = check_for_updates(st.session_state.tracker.get_version())
+    st.session_state.update_check = (
+        {'available': True, 'version': new_version, 'url': url} if is_available
+        else {'available': False}
+    )
 
 if 'feedback' not in st.session_state:
     st.session_state.feedback = None

--- a/tests/test_TimeTracker.py
+++ b/tests/test_TimeTracker.py
@@ -2,6 +2,7 @@ import unittest
 import unittest.mock
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timedelta, date
 
@@ -199,6 +200,37 @@ class TestTimeTracker(unittest.TestCase):
         self.tracker._check_and_install_dependencies()
 
         mock_subprocess.assert_not_called()
+        mock_exit.assert_not_called()
+
+    @unittest.mock.patch('tt.TimeTracker.distributions')
+    @unittest.mock.patch('subprocess.check_call')
+    @unittest.mock.patch('sys.exit')
+    @unittest.mock.patch('builtins.open', new_callable=unittest.mock.mock_open, read_data="packageB")
+    @unittest.mock.patch('os.path.exists')
+    def test_check_and_install_dependencies_timeout(self, mock_exists, mock_open, mock_exit, mock_subprocess, mock_distributions):
+        """
+        Regression test: with no internet connection, pip's own DNS
+        resolution can hang far longer than any of pip's own request
+        timeouts (which never even start ticking until DNS resolves), so
+        subprocess.check_call() needs an explicit timeout= or it will wait
+        forever - hanging the whole app before any UI is shown, since this
+        runs from initialize_dependencies() at startup. Simulates that hang
+        via subprocess.TimeoutExpired (what check_call raises once its own
+        timeout=PIP_INSTALL_TIMEOUT fires and kills the child) and asserts
+        the app logs a warning and keeps going instead of hanging or
+        crashing.
+        """
+        mock_exists.return_value = True
+        mock_distributions.return_value = []  # nothing installed
+        mock_subprocess.side_effect = subprocess.TimeoutExpired(cmd="pip", timeout=self.tracker.PIP_INSTALL_TIMEOUT)
+
+        self.tracker._check_and_install_dependencies()
+
+        mock_subprocess.assert_called_once()
+        _args, kwargs = mock_subprocess.call_args
+        self.assertEqual(kwargs.get('timeout'), self.tracker.PIP_INSTALL_TIMEOUT)
+        # Installation "failed" (timed out) - must NOT exit(0) to restart,
+        # since there is nothing new to restart into.
         mock_exit.assert_not_called()
 
     # --- General Method Tests ---

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,168 @@
+import unittest
+import unittest.mock
+import os
+import sys
+import threading
+import time
+
+# Add parent directory to path to import modules from root
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import requests
+import update
+
+
+class TestUpdate(unittest.TestCase):
+    """
+    Unit tests for update.py's check_for_updates() and download_update().
+
+    These cover both the pre-existing "no internet" behavior (a raised
+    requests exception is caught and turned into a safe default return
+    value) and today's fix: a network call that never returns at all
+    (simulating a DNS black hole) must still make check_for_updates()/
+    download_update() return within their configured deadline instead of
+    hanging the whole process.
+    """
+
+    def setUp(self):
+        """Runs before each test to make sure no leftover update.zip exists."""
+        if os.path.exists(update.UPDATE_ZIP_FILE):
+            os.remove(update.UPDATE_ZIP_FILE)
+
+    def tearDown(self):
+        """Runs after each test to clean up any update.zip created by a test."""
+        if os.path.exists(update.UPDATE_ZIP_FILE):
+            os.remove(update.UPDATE_ZIP_FILE)
+
+    # --- check_for_updates() ---
+
+    @unittest.mock.patch('update._get_github_repo_from_config')
+    @unittest.mock.patch('update.requests.get')
+    def test_check_for_updates_happy_path_new_version_available(self, mock_get, mock_get_repo):
+        """A newer tag_name on GitHub should be reported as an available update."""
+        mock_get_repo.return_value = "someuser/somerepo"
+        mock_response = unittest.mock.MagicMock()
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"tag_name": "v99.0", "zipball_url": "http://x/z"}
+        mock_get.return_value = mock_response
+
+        result = update.check_for_updates("1.0")
+
+        self.assertEqual(result, (True, "99.0", "http://x/z"))
+
+    @unittest.mock.patch('update._get_github_repo_from_config')
+    @unittest.mock.patch('update.requests.get')
+    def test_check_for_updates_no_update_available(self, mock_get, mock_get_repo):
+        """A tag_name older than the current version should report no update."""
+        mock_get_repo.return_value = "someuser/somerepo"
+        mock_response = unittest.mock.MagicMock()
+        mock_response.raise_for_status = unittest.mock.MagicMock()
+        mock_response.json.return_value = {"tag_name": "v0.5", "zipball_url": "http://x/z"}
+        mock_get.return_value = mock_response
+
+        result = update.check_for_updates("1.0")
+
+        self.assertEqual(result, (False, None, None))
+
+    @unittest.mock.patch('update._get_github_repo_from_config')
+    @unittest.mock.patch('update.requests.get')
+    def test_check_for_updates_request_exception_returns_safely(self, mock_get, mock_get_repo):
+        """
+        Existing behavior (predates today's fix): a network error raised by
+        requests.get must be caught and turned into the safe "no update"
+        default, never propagated to the caller.
+        """
+        mock_get_repo.return_value = "someuser/somerepo"
+        mock_get.side_effect = requests.exceptions.ConnectionError("no route to host")
+
+        result = update.check_for_updates("1.0")
+
+        self.assertEqual(result, (False, None, None))
+
+    @unittest.mock.patch('update.UPDATE_CHECK_DEADLINE', 1)
+    @unittest.mock.patch('update._get_github_repo_from_config')
+    @unittest.mock.patch('update.requests.get')
+    def test_check_for_updates_hung_network_call_returns_within_deadline(self, mock_get, mock_get_repo):
+        """
+        Regression test for today's fix: even if requests.get NEVER returns
+        (simulating a true DNS black-hole, not just a slow response),
+        check_for_updates() must still come back within UPDATE_CHECK_DEADLINE
+        instead of hanging forever.
+        """
+        mock_get_repo.return_value = "someuser/somerepo"
+        mock_get.side_effect = lambda *args, **kwargs: threading.Event().wait()
+
+        start = time.monotonic()
+        result = update.check_for_updates("1.0")
+        elapsed = time.monotonic() - start
+
+        self.assertEqual(result, (False, None, None))
+        self.assertLess(elapsed, 5, "check_for_updates() did not return within its deadline")
+
+    # --- download_update() ---
+
+    @unittest.mock.patch('update.DOWNLOAD_DEADLINE', 1)
+    @unittest.mock.patch('update.requests.get')
+    def test_download_update_hung_network_call_returns_within_deadline(self, mock_get):
+        """
+        Regression test for today's fix: even if requests.get NEVER returns,
+        download_update() must still come back within DOWNLOAD_DEADLINE
+        instead of hanging forever.
+        """
+        mock_get.side_effect = lambda *args, **kwargs: threading.Event().wait()
+
+        start = time.monotonic()
+        result = update.download_update("http://x/z")
+        elapsed = time.monotonic() - start
+
+        self.assertFalse(result)
+        self.assertLess(elapsed, 5, "download_update() did not return within its deadline")
+
+    @unittest.mock.patch('update.requests.get')
+    def test_download_update_request_exception_returns_safely(self, mock_get):
+        """
+        Existing behavior (predates today's fix): a network error raised by
+        requests.get must be caught and turned into a safe False return,
+        never propagated to the caller.
+        """
+        mock_get.side_effect = requests.exceptions.ConnectionError("no route to host")
+
+        result = update.download_update("http://x/z")
+
+        self.assertFalse(result)
+
+    # --- should_check_for_updates() ---
+
+    def test_should_check_for_updates_first_time_for_a_menu(self):
+        """No prior check recorded at all - a fresh session_state - must check."""
+        self.assertTrue(update.should_check_for_updates({}, "today_view"))
+
+    def test_should_check_for_updates_same_menu_as_last_check_skips(self):
+        """
+        Regression test: rerunning the *same* view (a keystroke, a periodic
+        auto-refresh tick, ...) must NOT re-trigger a check - only an actual
+        view change should.
+        """
+        session_state = {"_update_checked_for_menu": "today_view"}
+        self.assertFalse(update.should_check_for_updates(session_state, "today_view"))
+
+    def test_should_check_for_updates_different_menu_triggers_recheck(self):
+        """Navigating to a different view than the one last checked must check again."""
+        session_state = {"_update_checked_for_menu": "today_view"}
+        self.assertTrue(update.should_check_for_updates(session_state, "reporting"))
+
+    def test_should_check_for_updates_returning_to_a_previous_menu_rechecks(self):
+        """
+        Only the single most-recently-checked menu is remembered (not a set
+        of every menu ever visited this session) - navigating back to a view
+        checked earlier, but not immediately before this one, must check
+        again too. This matches "check on every view change" literally,
+        including revisits, while still skipping repeated reruns of the
+        view you're currently on.
+        """
+        session_state = {"_update_checked_for_menu": "reporting"}
+        self.assertTrue(update.should_check_for_updates(session_state, "today_view"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tt/TimeTracker.py
+++ b/tt/TimeTracker.py
@@ -43,6 +43,14 @@ class TimeTracker:
     STATUS_CLOSED = "closed"
     STATUS_DONE = "done"
     HIDDEN_PROJECT = "hide"
+    # Hard ceiling per package for the pip-install subprocess below. pip's own
+    # request/retry timeouts only bound its HTTP phase, not the DNS lookup
+    # that happens first - with no internet connection that lookup can hang
+    # far longer than pip's own timeouts, and subprocess.check_call() has no
+    # timeout of its own unless we pass one. Set generously above a normal
+    # (even slow) install so this only ever kicks in for that dead-network
+    # case, where subprocess's timeout=<N> kills the pip child outright.
+    PIP_INSTALL_TIMEOUT = 120
 
     def __init__(self, file_path=None):
         """
@@ -109,9 +117,15 @@ class TimeTracker:
                 for package in missing_packages:
                     print(_("Installing {package}...").format(package=package))
                     try:
-                        subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+                        subprocess.check_call(
+                            [sys.executable, "-m", "pip", "install", package],
+                            timeout=self.PIP_INSTALL_TIMEOUT,
+                        )
                     except subprocess.CalledProcessError:
                         print(_("Failed to install {package}. Continuing without it.").format(package=package))
+                        failed_packages.append(package)
+                    except subprocess.TimeoutExpired:
+                        print(_("Timed out installing {package} (no internet connection?). Continuing without it.").format(package=package))
                         failed_packages.append(package)
 
                 if not failed_packages:

--- a/update.py
+++ b/update.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import threading
 from i18n import _
 import requests
 import zipfile
@@ -11,6 +12,71 @@ from i18n import _ # Import translation function
 UPDATE_ZIP_FILE = "update.zip"
 CONFIG_FILE = "config.json"
 PROTECTED_FILES = ["data.json", "config.json"] # Files that should not be overwritten during an update if they already exist
+
+# requests' own `timeout=` only bounds the connect()/read() phases of a
+# socket that already knows its target address - it does NOT cover DNS
+# resolution (socket.getaddrinfo()), which runs first. With no internet
+# connection at all (especially on Windows, or whenever DNS packets are
+# silently dropped rather than actively refused), that lookup can hang far
+# longer than any requests-level timeout - the classic "app hangs with no
+# internet" gotcha. These deadlines are set comfortably above the request's
+# own worst case (timeout applies separately to connect and read, so
+# ~2x timeout) so they only ever kick in for that pathological hang.
+UPDATE_CHECK_DEADLINE = 15   # seconds - hard ceiling for the "is there a new release" request
+DOWNLOAD_DEADLINE = 65       # seconds - hard ceiling for opening the download connection
+
+
+def _call_with_deadline(func, deadline, *args, **kwargs):
+    """
+    Runs func(*args, **kwargs) in a daemon thread and waits at most
+    `deadline` seconds for it. Raises TimeoutError if it's still running
+    after that.
+
+    A daemon thread - not concurrent.futures.ThreadPoolExecutor - is
+    deliberate: ThreadPoolExecutor registers its worker threads to be
+    joined at interpreter exit, so a call that's genuinely stuck (e.g. DNS
+    resolution that never gets a response) would still hang the whole app
+    at shutdown even though we stopped waiting for it here. A daemon
+    thread is hard-killed by the interpreter on exit instead, so a stuck
+    lookup can never block the app from closing.
+    """
+    result = {}
+
+    def _target():
+        try:
+            result['value'] = func(*args, **kwargs)
+        except BaseException as exc:
+            result['error'] = exc
+
+    worker = threading.Thread(target=_target, daemon=True)
+    worker.start()
+    worker.join(deadline)
+    if worker.is_alive():
+        raise TimeoutError(f"Operation timed out after {deadline}s")
+    if 'error' in result:
+        raise result['error']
+    return result.get('value')
+
+
+def should_check_for_updates(session_state, current_menu):
+    """
+    True iff we haven't already checked for updates for this exact
+    menu/view since it was last navigated to - i.e. once per view change,
+    not once per rerun of the *same* view (a keystroke, a periodic
+    auto-refresh tick, ...), which would hit GitHub far more often than
+    the view itself actually changes.
+
+    Takes session_state/current_menu as plain arguments (rather than a
+    caller reaching into a global session object itself) purely so this
+    decision stays testable without any UI framework running - session_state
+    only needs a .get(key, default) method, so a Streamlit session_state or
+    a plain dict both work.
+
+    :param session_state: mapping-like object with .get(key, default)
+    :param current_menu: identifier of the view currently being shown
+    :return: True if check_for_updates() should be (re-)run now
+    """
+    return session_state.get('_update_checked_for_menu') != current_menu
 
 def _get_github_repo_from_config():
     """Reads the GitHub repository slug from config.json."""
@@ -37,10 +103,10 @@ def check_for_updates(current_version_str):
 
     api_url = f"https://api.github.com/repos/{github_repo}/releases/latest"
     try:
-        response = requests.get(api_url, timeout=5)
+        response = _call_with_deadline(requests.get, UPDATE_CHECK_DEADLINE, api_url, timeout=5)
         response.raise_for_status()
         latest_release = response.json()
-        
+
         latest_version_str = latest_release.get("tag_name", "").lstrip('v')
         current_version = parse_version(current_version_str)
         latest_version = parse_version(latest_version_str)
@@ -55,11 +121,13 @@ def check_for_updates(current_version_str):
                 print(_("Error: Download URL for the new version not found."))
                 return False, None, None
 
+    except TimeoutError:
+        print(_("Warning: Update check timed out (no internet connection?). Skipping."))
     except requests.exceptions.RequestException as e:
         print(_("Error checking for updates: {error}").format(error=e))
     except Exception as e:
         print(_("An unexpected error occurred while checking for updates: {error}").format(error=e))
-        
+
     return False, None, None
 
 def download_update(url):
@@ -71,13 +139,18 @@ def download_update(url):
     """
     try:
         print(_("Downloading update..."))
-        response = requests.get(url, stream=True, timeout=30)
+        response = _call_with_deadline(requests.get, DOWNLOAD_DEADLINE, url, stream=True, timeout=30)
         response.raise_for_status()
         with open(UPDATE_ZIP_FILE, 'wb') as f:
             for chunk in response.iter_content(chunk_size=8192):
                 f.write(chunk)
         print(_("Download complete. The update will be installed on the next start."))
         return True
+    except TimeoutError:
+        print(_("Error: Connecting to the update server timed out (no internet connection?)."))
+        if os.path.exists(UPDATE_ZIP_FILE):
+            os.remove(UPDATE_ZIP_FILE) # Clean up partial download
+        return False
     except requests.exceptions.RequestException as e:
         print(_("Error downloading the update: {error}").format(error=e))
         if os.path.exists(UPDATE_ZIP_FILE):


### PR DESCRIPTION
## Summary

Two independent fixes, both around code hanging indefinitely with no clear failure:

- **SOAP server import hang**: spyne 2.14.0 (the only PyPI release) vendors an old copy of `six` whose meta path importer lacks Python 3.12's required `find_spec()`, so `import spyne` itself fails with `ModuleNotFoundError: No module named 'spyne.util.six.moves'`. On Python 3.13+, a second break surfaces (spyne's SOAP11/WSGI code still does `import cgi`, removed from the stdlib in 3.13). Both were causing every test in `tests/test_TimeTrackerSOAP_Server.py` to silently skip via a broad `except SystemExit` — the SOAP interface had effectively zero real test coverage.
- **App hangs with no internet connection**: `requests`'/`subprocess`'s own `timeout=` only bounds the connect()/read() phases of a socket that already knows its target — it never covers DNS resolution, which runs first and can hang far longer than any such timeout with no network route at all. Two call sites were affected: `tt/TimeTracker.py`'s `_check_and_install_dependencies()` (a bare `pip install` subprocess with **no** timeout, running before any UI in every entry point) and `update.py`'s GitHub release check (called once at CLI/GUI exit, and — after finding my branch was 14+ PRs behind `main` and merging up — once per Streamlit session on `sl/SL_Menu.py`'s "new version available" banner).

## Changes

- `TimeTrackerSOAP_Server.py`: two import-time shims — one loads spyne's vendored `six.py` directly and patches `find_spec()` onto its importer; the other registers a minimal `cgi` stand-in (`parse_header` only, via `email.message.EmailMessage`) when the real module is absent. Both no-ops if spyne is ever fixed upstream, no new dependencies.
- `update.py`: new `_call_with_deadline()` helper runs the actual network call in a **daemon thread** with a bounded `join()` — deliberately not `concurrent.futures.ThreadPoolExecutor`, which registers worker threads to be joined at interpreter exit and would just relocate a genuine hang to app shutdown. `check_for_updates()`/`download_update()` now catch the resulting `TimeoutError` alongside their existing `requests.exceptions.RequestException` handling. Also adds `should_check_for_updates(session_state, current_menu)`, a small testable helper for the throttling decision below.
- `tt/TimeTracker.py`: `_check_and_install_dependencies()`'s `pip install` subprocess now has a `PIP_INSTALL_TIMEOUT` (120s); a timeout is treated like a failed install (skip the package, keep going) instead of hanging startup indefinitely.
- `install.py`: same timeout fix applied to the standalone setup script for consistency.
- `sl/SL_Menu.py`: the "new version available" banner now re-checks on every view change (not just once per session) while still skipping repeated reruns of the *same* view (a keystroke, the 5s auto-refresh tick), via `should_check_for_updates()`.
- `tests/test_update.py` (new) and `tests/test_TimeTracker.py`: regression tests simulating network/subprocess calls that never return, asserting bounded return times; tests for the view-change throttling decision.

## Test plan

- [x] Full suite passes: 236 tests, 0 failures (`python -m unittest discover tests`)
- [x] SOAP fix verified in fresh venvs across Python 3.10–3.14 (`pip install spyne lxml`), confirming `tests/test_TimeTrackerSOAP_Server.py` executes and passes instead of skipping
- [x] Update-hang fix verified with simulated hung network calls (deadline patched low in tests) — bounded return confirmed
- [x] Daemon-thread-vs-`ThreadPoolExecutor` design claim verified empirically: a control test using `ThreadPoolExecutor` for the same scenario genuinely hung process exit, confirming the daemon-thread approach is necessary, not just theoretically nicer
- [x] Live-tested in a browser: started the Streamlit app, navigated across multiple views, confirmed the version banner appears/persists correctly with no console errors

## Notes for reviewer

- No new dependencies added anywhere.
- German-locale translations for the two new user-facing warning strings in `update.py` were **not** added (they fall back to English, same as one pre-existing untranslated string already does) — this repo's translations are historically done in dedicated follow-up commits with proper `msgfmt` tooling, not alongside the code change.
- A related, lower-priority gap was found but intentionally left out of this PR: `fetch_emails_to_tasks()`'s IMAP connection has the same zero-timeout pattern, but it's opt-in (disabled by default) and only reached via explicit user action, so it doesn't block startup the way the fixes above did.
